### PR TITLE
improvements to prepare_tables_from_sql_file method

### DIFF
--- a/src/shift_left/src/shift_left/core/deployment_mgr.py
+++ b/src/shift_left/src/shift_left/core/deployment_mgr.py
@@ -516,14 +516,17 @@ def prepare_tables_from_sql_file(sql_file_name: str,
     config = get_config()
     compute_pool_id = compute_pool_id or config['flink']['compute_pool_id']
     transformer = statement_mgr.get_or_build_sql_content_transformer()
+    stmnt_suffix = datetime.now().strftime("%Y%m%d%H%M%S")
     with open(sql_file_name, "r") as f:
         idx=0
         for line in f:
+            if line.lstrip().startswith('--'):
+                continue
             _, sql_out= transformer.update_sql_content(line, 
                                                        "", 
                                                        "")
             print(sql_out)
-            statement_name = f"prepare-table-{idx}"
+            statement_name = f"prepare-table-{stmnt_suffix}-{idx}"
             statement = statement_mgr.post_flink_statement(compute_pool_id, 
                                                            statement_name, 
                                                            sql_out)


### PR DESCRIPTION
Address these issues
1. Skip comments in the SQL file
2. If a statement fails it cannot delete the statement, it fails on the next run as the stment name is static between runs. Added uniqueness to each run by using a timestamp in the statement name.   