### PR TITLE
Upgrade housekeep_statement to pause statements in a pool

### DIFF
--- a/src/shift_left/src/shift_left/core/statement_mgr.py
+++ b/src/shift_left/src/shift_left/core/statement_mgr.py
@@ -156,6 +156,13 @@ def delete_statement_if_exists(statement_name) -> str | None:
         statement_list.pop(statement_name)
     return result
 
+def patch_statement_if_exists(statement_name: str, stopped: bool) -> str | None:
+    logger.info(f"Enter with {statement_name}")
+    config = get_config()
+    client = ConfluentCloudClient(config)
+    result=client.patch_flink_statement(statement_name, stopped)
+    return result
+
 def get_statement_info(statement_name: str) -> None | StatementInfo:
     """
     Get the statement given the statement name


### PR DESCRIPTION
Enhanced housekeep_statements to allow for delete, pause, resume statements in a specific pool

- Added  method patch_flink_statement in ccloud_client.py
- Added method patch_statement_if_exists in statement_mgr.py
- Enhanced  method housekeep_statements in project.py

Unit Tests passed.